### PR TITLE
rockchip: Fix port/LED order on NanoPi R6S

### DIFF
--- a/target/linux/rockchip/armv8/base-files/etc/board.d/01_leds
+++ b/target/linux/rockchip/armv8/base-files/etc/board.d/01_leds
@@ -35,9 +35,9 @@ friendlyelec,nanopi-r6c)
 	ucidef_set_led_netdev "led1" "LED1" "green:led1" "eth2"
 	;;
 friendlyelec,nanopi-r6s)
-	ucidef_set_led_netdev "wan" "WAN" "green:wan" "eth2"
-	ucidef_set_led_netdev "lan" "LAN" "green:lan" "eth0"
-	ucidef_set_led_netdev "lan2" "LAN2" "green:lan1" "eth1"
+	ucidef_set_led_netdev "wan" "WAN" "green:wan" "eth1"
+	ucidef_set_led_netdev "lan" "LAN" "green:lan" "eth2"
+	ucidef_set_led_netdev "lan2" "LAN2" "green:lan1" "eth0"
 	;;
 friendlyelec,nanopi-r6c-plus)
 	ucidef_set_led_netdev "wan" "WAN" "green:wan" "eth2"

--- a/target/linux/rockchip/armv8/base-files/etc/board.d/02_network
+++ b/target/linux/rockchip/armv8/base-files/etc/board.d/02_network
@@ -21,7 +21,7 @@ rockchip_setup_interfaces()
 		ucidef_set_interfaces_lan_wan 'eth1' 'eth0'
 		;;
 	friendlyelec,nanopi-r6s)
-		ucidef_set_interfaces_lan_wan 'eth1 eth0' 'eth2'
+		ucidef_set_interfaces_lan_wan 'eth2 eth0' 'eth1'
 		;;
 	friendlyelec,nanopi-r6c-plus)
 		ucidef_set_interfaces_lan_wan 'eth0 eth1 eth3' 'eth2'


### PR DESCRIPTION
This commit fixes the ethernet device and LED setup on the FriendlyElec NanoPi R6S to match the physical layout/labels on the case of the device.

The actual case-label, ethernet device, and underlying NIC device, from left-to-right on back of case:
 * "LAN2" - eth0 - rk_gmac-dwmac fe1c0000.ethernet
 * "LAN1" - eth2 - r8169 0004:41:00.0
 * "WAN"  - eth1 - r8169 0003:31:00.0

The actual case-label and LED sys-name, from left-to-right on the front of case:
 * "WAN" - "green:wan"
 * "1"   - "green:lan"
 * "2"   - "green:lan1"

(This is the layout on my R6S box; I assume it is the same for all boxes, but I have no idea how "ethN" device names are assigned to the underlying NIC hardware.)

I don't think any change to the smp-affinity is required, since this commit swaps the use of the eth1 and eth2 devices, which were already both assigned to the "big" cores (as I understand it).
